### PR TITLE
Add daily speech summarization using local LLM

### DIFF
--- a/listener.py
+++ b/listener.py
@@ -23,7 +23,8 @@ def audio_callback(indata, frames, time, status):
     q.put(indata.copy())
 
 def classify_and_transcribe(audio_data, samplerate):
-    # Save temp WAV
+    """Classify audio and transcribe segments containing speech."""
+
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     wav_path = f"data/{timestamp}.wav"
     write(wav_path, samplerate, audio_data)
@@ -34,11 +35,17 @@ def classify_and_transcribe(audio_data, samplerate):
     yamnet_classes = pd.read_csv(
         hub.resolve("https://storage.googleapis.com/audioset/yamnet/yamnet_class_map.csv")
     )
+
     top_class = yamnet_classes['display_name'][scores_np.mean(axis=0).argmax()]
 
-    # Transcribe with Whisper
+    # Only transcribe if speech is detected
+    if "speech" not in top_class.lower():
+        return
+
     result = whisper_model.transcribe(wav_path)
     transcript = result['text'].strip()
+    if not transcript:
+        return
 
     summary = {
         "time": timestamp,

--- a/model_manager.py
+++ b/model_manager.py
@@ -1,0 +1,13 @@
+import os
+from transformers import pipeline
+import whisper
+
+# Pre-load models to ensure they are cached locally
+
+def ensure_models():
+    """Download required models on first run."""
+    # Whisper model
+    whisper.load_model("small")
+    # Huggingface summarization model
+    pipeline("summarization", model="sshleifer/distilbart-cnn-12-6")
+

--- a/model_manager.py
+++ b/model_manager.py
@@ -1,13 +1,20 @@
 import os
-from transformers import pipeline
 import whisper
+from transformers import pipeline
 
 # Pre-load models to ensure they are cached locally
 
+
 def ensure_models():
-    """Download required models on first run."""
-    # Whisper model
-    whisper.load_model("small")
-    # Huggingface summarization model
-    pipeline("summarization", model="sshleifer/distilbart-cnn-12-6")
+    """Load models if they are available locally."""
+    root = os.path.expanduser(os.getenv("WHISPER_CACHE", "~/.cache/whisper"))
+    try:
+        whisper.load_model("small", download_root=root)
+    except Exception as exc:
+        print(f"Warning: could not load Whisper model: {exc}")
+
+    try:
+        pipeline("summarization", model="sshleifer/distilbart-cnn-12-6", local_files_only=True)
+    except Exception as exc:
+        print(f"Warning: could not load summarization model: {exc}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ sounddevice
 numpy
 scipy
 pandas
+transformers
+torch

--- a/summarizer.py
+++ b/summarizer.py
@@ -1,7 +1,12 @@
+"""Generate daily summaries of captured speech."""
+
 import os
-import pandas as pd
 from datetime import datetime
+
+import pandas as pd
 from transformers import pipeline
+
+from model_manager import ensure_models
 
 SUMMARY_MODEL = "sshleifer/distilbart-cnn-12-6"
 
@@ -24,6 +29,7 @@ def build_narrative(df):
 
 
 def summarize_date(date_str):
+    ensure_models()
     df = load_log()
     if df.empty:
         print("No transcripts found.")
@@ -36,8 +42,13 @@ def summarize_date(date_str):
         return
 
     text = build_narrative(day_df)
-    summarizer = pipeline("summarization", model=SUMMARY_MODEL)
-    result = summarizer(text, max_length=200, min_length=50, do_sample=False)[0]
+    summarizer = pipeline("summarization", model=SUMMARY_MODEL, local_files_only=True)
+    prompt = (
+        "Summarize the following conversation. Include who said what, when it "
+        "happened, and any context about where or why if available: "
+        + text
+    )
+    result = summarizer(prompt, max_length=200, min_length=50, do_sample=False)[0]
     summary_text = result["summary_text"]
 
     out_file = f"data/summary_{date_str}.txt"

--- a/summarizer.py
+++ b/summarizer.py
@@ -1,0 +1,52 @@
+import os
+import pandas as pd
+from datetime import datetime
+from transformers import pipeline
+
+SUMMARY_MODEL = "sshleifer/distilbart-cnn-12-6"
+
+
+def load_log(log_path="data/log.csv"):
+    if not os.path.exists(log_path):
+        return pd.DataFrame(columns=["time", "class", "transcript"])
+    df = pd.read_csv(log_path, names=["time", "class", "transcript"])
+    df["time"] = pd.to_datetime(df["time"])
+    return df
+
+
+def build_narrative(df):
+    """Create a textual narrative from log rows."""
+    pieces = []
+    for _, row in df.iterrows():
+        timestamp = row["time"].strftime("%H:%M")
+        pieces.append(f"At {timestamp}, someone said: '{row['transcript']}'.")
+    return " ".join(pieces)
+
+
+def summarize_date(date_str):
+    df = load_log()
+    if df.empty:
+        print("No transcripts found.")
+        return
+
+    target_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+    day_df = df[df["time"].dt.date == target_date]
+    if day_df.empty:
+        print(f"No transcripts for {date_str}")
+        return
+
+    text = build_narrative(day_df)
+    summarizer = pipeline("summarization", model=SUMMARY_MODEL)
+    result = summarizer(text, max_length=200, min_length=50, do_sample=False)[0]
+    summary_text = result["summary_text"]
+
+    out_file = f"data/summary_{date_str}.txt"
+    with open(out_file, "w") as f:
+        f.write(summary_text)
+    print(f"Summary saved to {out_file}")
+    print(summary_text)
+
+
+if __name__ == "__main__":
+    today = datetime.now().strftime("%Y-%m-%d")
+    summarize_date(today)


### PR DESCRIPTION
## Summary
- rename model manager and preload summarization model
- filter non-speech audio before transcription
- capture transcripts in `log.csv`
- provide `summarizer.py` to generate daily narrative summaries
- add `transformers` and `torch` dependencies for local LLM

## Testing
- `python -m py_compile listener.py model_manager.py summarizer.py`
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `python summarizer.py` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_688cf55ab69c8328b54c33be211bcfee